### PR TITLE
Add vehicle spawning GUI and server-side handling for custom model IDs

### DIFF
--- a/[examples]/test_vehicles/c_vehicles.lua
+++ b/[examples]/test_vehicles/c_vehicles.lua
@@ -1,0 +1,84 @@
+local screenW, screenH = guiGetScreenSize()
+
+
+local windowW, windowH = 300, 200
+local windowX, windowY = (screenW - windowW) / 2, (screenH - windowH) / 2
+local window = guiCreateWindow(windowX, windowY, windowW, windowH, "Vehicle Spawner", false)
+
+local label = guiCreateLabel(20, 40, 260, 30, "Enter Vehicle ID:", false, window)
+guiLabelSetHorizontalAlign(label, "center")
+
+local input = guiCreateEdit(50, 70, 200, 30, "", false, window)
+
+local spawnButton = guiCreateButton(50, 120, 200, 40, "Spawn Vehicle", false, window)
+
+guiSetVisible(window, false)
+
+
+function requestVehicleSpawn()
+    local vehicleIDText = guiGetText(input)
+    local vehicleID = tonumber(vehicleIDText)
+
+    if not vehicleID then
+        outputChatBox("Error: Please enter a valid number!", 255, 0, 0)
+        return
+    end
+
+    -- Get player position and rotation
+    local x, y, z = getElementPosition(localPlayer)
+    local rot = getPedRotation(localPlayer)
+
+    -- Calculate spawn position in front of the player
+    local offsetDistance = 5
+    local spawnX = x + offsetDistance * math.sin(math.rad(-rot))
+    local spawnY = y + offsetDistance * math.cos(math.rad(-rot))
+
+    -- Hide GUI
+    guiSetVisible(window, false)
+    showCursor(false)
+
+    -- Clear input
+    guiSetText(input, "")
+
+    outputChatBox("Attempting to spawn vehicle ID: " .. vehicleID .. "...", 255, 255, 0)
+    outputDebugString("Sending vehicle ID: " .. vehicleID, 3)
+
+    -- Use root element as the target for server event
+    triggerServerEvent("spawnVehicleServer", localPlayer, vehicleID, spawnX, spawnY, z, rot)
+end
+
+addEventHandler("onClientGUIClick", spawnButton, requestVehicleSpawn, false)
+
+-- event handler for server responses with improved debugging
+addEvent("vehicleSpawnResponse", true)
+addEventHandler("vehicleSpawnResponse", localPlayer, function(success, message)
+    outputDebugString("Received vehicle spawn response: " .. tostring(success) .. " - " .. tostring(message), 3)
+    if success then
+        outputChatBox("Success: " .. message, 0, 255, 0)
+    else
+        outputChatBox("Error: " .. message, 255, 0, 0)
+    end
+end)
+
+-- enter key handler for the input
+function onInputEnter()
+    if source == input then
+        requestVehicleSpawn()
+    end
+end
+
+addEventHandler("onClientGUIAccepted", input, onInputEnter)
+
+-- toggle GUI visibility
+function toggleGUI()
+    local visible = guiGetVisible(window)
+    guiSetVisible(window, not visible)
+    showCursor(not visible)
+
+    if not visible then -- If showing the window
+        guiBringToFront(input)
+        guiFocus(input)
+    end
+end
+
+bindKey("F4", "down", toggleGUI) -- F4 to open/close the GUI

--- a/[examples]/test_vehicles/meta.xml
+++ b/[examples]/test_vehicles/meta.xml
@@ -1,7 +1,9 @@
 <meta>
     <include resource="newmodels_azul" minversion="5.0.0"/>
     <script src="s_vehicles.lua" type="server"/>
+    <script src="c_vehicles.lua" type="client"/>
     <aclrequest>
         <right name="function.loadstring" access="true"/>
+        <right name="function.outputDebugString" access="true"/>
     </aclrequest>
 </meta>

--- a/[examples]/test_vehicles/s_vehicles.lua
+++ b/[examples]/test_vehicles/s_vehicles.lua
@@ -1,5 +1,5 @@
 -- Loads newmodels functions, which allow usage of custom model IDs "as if they were normal IDs"
-exports.newmodels_azul:import()
+loadstring(exports.newmodels_azul:import())()
 
 -- Vehicle model, x,y,z, rx,ry,rz, interior,dimension
 local VEHICLE_SPAWNS = {

--- a/[examples]/test_vehicles/s_vehicles.lua
+++ b/[examples]/test_vehicles/s_vehicles.lua
@@ -1,12 +1,12 @@
 -- Loads newmodels functions, which allow usage of custom model IDs "as if they were normal IDs"
-loadstring(exports.newmodels_azul:import())()
+exports.newmodels_azul:import()
 
 -- Vehicle model, x,y,z, rx,ry,rz, interior,dimension
 local VEHICLE_SPAWNS = {
-    {525, -938.74, 1034.21, 23.59, 3.42, 2.85, 20.27, 0, 0},
-    {490, -941.95, 1043.03, 24.25, 355.90, 356.51, 199.00, 0, 0},
-    {-1, -951.79, 1069.05, 25.96, 356.28, 356.34, 204.01, 0, 0},
-    {-5, -944.88, 1051.90, 24.84, 355.97, 356.23, 198.86, 0, 0},
+    { 525, -938.74, 1034.21, 23.59, 3.42,   2.85,   20.27,  0, 0 },
+    { 490, -941.95, 1043.03, 24.25, 355.90, 356.51, 199.00, 0, 0 },
+    { -1,  -951.79, 1069.05, 25.96, 356.28, 356.34, 204.01, 0, 0 },
+    { -5,  -944.88, 1051.90, 24.84, 355.97, 356.23, 198.86, 0, 0 },
 }
 
 local function createVehicles()
@@ -33,12 +33,56 @@ addCommandHandler("myvehicle", function(player)
     local model = getElementModel(vehicle)
     local baseModel = getElementBaseModel(vehicle)
     if model == baseModel then
-        outputChatBox("This vehicle has the default model ID " .. model .. " ("..(tostring(getVehicleNameFromModel(model)) or "")..")", player, 0, 255, 0)
+        outputChatBox(
+            "This vehicle has the default model ID " .. model .. " (" ..
+            (tostring(getVehicleNameFromModel(model)) or "") .. ")", player, 0, 255, 0)
     else
         if not baseModel then
-            outputChatBox("This vehicle has the custom model ID " .. model .. ", but the base model ID could not be determined", player, 255, 0, 0)
+            outputChatBox(
+                "This vehicle has the custom model ID " .. model .. ", but the base model ID could not be determined",
+                player,
+                255, 0, 0)
             return
         end
-        outputChatBox("This vehicle has the custom model ID " .. model .. ", which is based on the default model ID " .. baseModel .. " ("..(tostring(getVehicleNameFromModel(baseModel)) or "")..")", player, 0, 255, 0)
+        outputChatBox(
+            "This vehicle has the custom model ID " ..
+            model ..
+            ", which is based on the default model ID " ..
+            baseModel .. " (" .. (tostring(getVehicleNameFromModel(baseModel)) or "") .. ")", player, 0, 255, 0)
     end
 end, false, false)
+
+
+addEvent("spawnVehicleServer", true)
+addEventHandler("spawnVehicleServer", root, function(vehicleID, x, y, z, rot)
+    if not vehicleID then
+        triggerClientEvent(source, "vehicleSpawnResponse", source, false, "Invalid vehicle ID!")
+        return
+    end
+
+    -- Get the list of all custom models from newmodels_azul
+    local customModels = exports['newmodels_azul']:getCustomModels()
+
+    -- Check if this is a valid vehicle ID (either custom model or default vehicle ID)
+    local isValidCustomModel = customModels[vehicleID] and true or false
+    local isValidDefaultID = exports['newmodels_azul']:isDefaultID("vehicle", vehicleID)
+
+    -- If it's neither a valid custom model nor a default vehicle ID.. reject it
+    if not isValidCustomModel and not isValidDefaultID then
+        triggerClientEvent(source, "vehicleSpawnResponse", source, false, "Invalid vehicle ID: " .. vehicleID)
+        outputServerLog("Rejected invalid vehicle ID: " .. vehicleID)
+        return
+    end
+
+    -- now create the vehicle with the verified ID
+    local vehicle = exports['newmodels_azul']:createVehicle(vehicleID, x, y, z, 0, 0, rot)
+
+    if isElement(vehicle) then
+        local actualModel = getElementModel(vehicle)
+        triggerClientEvent(source, "vehicleSpawnResponse", source, true, "Vehicle spawned successfully!")
+        outputServerLog("Created vehicle with ID: " .. vehicleID .. ", actual model: " .. actualModel)
+    else
+        triggerClientEvent(source, "vehicleSpawnResponse", source, false, "Failed to spawn vehicle!")
+        outputServerLog("Failed to create vehicle with ID: " .. vehicleID)
+    end
+end)

--- a/newmodels_azul/scripts/optional/debug/s_debug.lua
+++ b/newmodels_azul/scripts/optional/debug/s_debug.lua
@@ -3,15 +3,33 @@ addCommandHandler("testveh", function(thePlayer, cmd, id)
     if not id then
         return outputChatBox("Syntax: /"..cmd.." <default or custom id>", thePlayer)
     end
-    local x,y,z = getElementPosition(thePlayer)
-    local rx,ry,rz = getElementRotation(thePlayer)
-    local element = createVehicle(id, x, y, z, rx, ry, rz)
+
+    -- Validate ID
+    local isValidCustomModel = exports.newmodels_azul:getCustomModels()[id] and true or false
+    local isValidDefaultID = exports.newmodels_azul:isDefaultID("vehicle", id)
+
+    if not isValidCustomModel and not isValidDefaultID then
+        return outputChatBox("Invalid vehicle ID: "..id, thePlayer)
+    end
+
+    local x, y, z = getElementPosition(thePlayer)
+    local rx, ry, rz = getElementRotation(thePlayer)
+
+    -- appropriate function to create the vehicle
+    local element
+    if isValidCustomModel then
+        element = exports.newmodels_azul:createVehicle(id, x, y, z, rx, ry, rz)
+    else
+        element = createVehicle(id, x, y, z, rx, ry, rz)
+    end
+
     if not element then
         return outputChatBox("Failed to create vehicle.", thePlayer)
     end
+
     setElementDimension(element, getElementDimension(thePlayer))
     setElementInterior(element, getElementInterior(thePlayer))
-    setElementPosition(thePlayer, x+2, y, z)
+    setElementPosition(thePlayer, x + 2, y, z)
     outputChatBox("Vehicle created with ID "..id..".", thePlayer)
 end, false, false)
 


### PR DESCRIPTION
- Fixed an issue where out-of-range IDs like 800195116 caused MTA to respawn vehicle ID 556  
- Added ID validation to check if it's a custom model or a valid default before calling createVehicle  
- If invalid, it throws an error to prevent fallback behavior  
- Changes made in s_debug.lua and s_vehicles.lua  
- Now supports using multiple custom models on the same element ID