### PR TITLE
fix(meta): Export isCustomModelCompatible function

### DIFF
--- a/newmodels_azul/meta.xml
+++ b/newmodels_azul/meta.xml
@@ -33,6 +33,7 @@
     <export function="getCustomModelName" type="shared"/>
     <export function="isValidElement" type="shared"/>
     <export function="getValidElementTypes" type="shared"/>
+    <export function="isCustomModelCompatible" type="shared"/>
 
     <!-- Files -->
     <file src="models/**/*.col"/>


### PR DESCRIPTION
The isCustomModelCompatible function was implemented in the core scripts but was not exported, making it inaccessible to other resources that depend on this library.

This commit adds the corresponding <export> tag to meta.xml, properly exposing the function and fixing potential "function not found" errors in dependent resources.