### PR TITLE
Remove restoreElementBaseModels() from onClientResourceStop event han…

### DIFF
--- a/newmodels_azul/scripts/core/client_logic.lua
+++ b/newmodels_azul/scripts/core/client_logic.lua
@@ -399,7 +399,6 @@ addEventHandler("newmodels_azul:receiveCustomModels", resourceRoot, function(cus
 end, false)
 
 addEventHandler("onClientResourceStop", resourceRoot, function()
-    restoreElementBaseModels()
     -- Free all allocated models instantly
     for customModel, _ in pairs(loadedModels) do
         freeAllocatedModelNow(customModel)


### PR DESCRIPTION
This fixes the crashes when disconnecting/stopping the resource and there's a ped/player element loaded.

The error happened because trying to set the element model of an already destroyed element causes a memory access violation error and crashed the game.

The ped/player elements were destroyed automatically by the engine when disconnecting, so this line is not necessary.